### PR TITLE
Adding OTP snippets

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -237,5 +237,22 @@
 		"body": "unless $1, do: $0",
 		"description": "unless (one line)",
 		"scope": "source.elixir"
+	},
+	"Supervisor": {
+		"prefix": "supervisor",
+		"body": [
+			"defmodule ${0:moduleName} do",
+			"\tuse Supervisor",
+			"",
+			"\tdef start_link(), do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)",
+			"",
+			"\tdef init([]) do",
+			"\t\tchildren = []",
+			"",
+			"\t\tSupervisor.init(children, strategy: :one_for_one)",
+			"\tend",
+			"end"
+		],
+		"description": "Insert code for a OTP Supervisor"
 	}
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -246,7 +246,7 @@
 			"",
 			"\tdef start_link(${args}) do",
 			"\t\tSupervisor.start_link(__MODULE__, [${args}], name: __MODULE__)",
-			"\tend"
+			"\tend",
 			"",
 			"\tdef init([${args}]) do",
 			"\t\tchildren = []",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -256,5 +256,35 @@
 			"end"
 		],
 		"description": "Insert code for a OTP Supervisor"
+	},
+	"DynamicSupervisor": {
+		"prefix": "dynamic_supervisor",
+		"body": [
+			"defmodule ${ModuleName} do",
+			"\tuse DynamicSupervisor",
+			"",
+			"\tdef start_link(${init_args}) do",
+			"\t\tDynamicSupervisor.start_link(__MODULE__, [${init_args}], name: __MODULE__)",
+			"\tend",
+			"",
+			"\tdef start_child(${child_args}) do",
+			"\t\tchild_spec = %{",
+				"\t\t\tid: ${ChildModule},",
+				"\t\t\tstart: {${ChildModule}, :start_link, [${child_args}]},",
+				"\t\t\trestart: :transient,",
+				"\t\t\tshutdown: :brutal_kill,",
+				"\t\t\ttype: :worker,",
+				"\t\t\tmodules: [${ChildModule}],",
+			"\t\t}",
+			"",
+			"\t\tDynamicSupervisor.start_child(__MODULE__, child_spec)",
+			"\tend",
+			"",
+			"\tdef init([${init_args}]) do",
+			"\t\tDynamicSupervisor.init(strategy: :one_for_one)",
+			"\tend",
+			"end"
+		],
+		"description": "Insert code for a DynamicSupervisor"
 	}
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -241,12 +241,14 @@
 	"Supervisor": {
 		"prefix": "supervisor",
 		"body": [
-			"defmodule ${0:moduleName} do",
+			"defmodule ${1:moduleName} do",
 			"\tuse Supervisor",
 			"",
-			"\tdef start_link(), do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)",
+			"\tdef start_link(${0:args}) do",
+			"\t\tSupervisor.start_link(__MODULE__, [${0:args}], name: __MODULE__)",
+			"\tend"
 			"",
-			"\tdef init([]) do",
+			"\tdef init([${0:args}]) do",
 			"\t\tchildren = []",
 			"",
 			"\t\tSupervisor.init(children, strategy: :one_for_one)",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -241,14 +241,14 @@
 	"Supervisor": {
 		"prefix": "supervisor",
 		"body": [
-			"defmodule ${1:moduleName} do",
+			"defmodule ${moduleName} do",
 			"\tuse Supervisor",
 			"",
-			"\tdef start_link(${0:args}) do",
-			"\t\tSupervisor.start_link(__MODULE__, [${0:args}], name: __MODULE__)",
+			"\tdef start_link(${args}) do",
+			"\t\tSupervisor.start_link(__MODULE__, [${args}], name: __MODULE__)",
 			"\tend"
 			"",
-			"\tdef init([${0:args}]) do",
+			"\tdef init([${args}]) do",
 			"\t\tchildren = []",
 			"",
 			"\t\tSupervisor.init(children, strategy: :one_for_one)",


### PR DESCRIPTION
I'd like to add several more involved  snippets for when you want to insert skeletons for OTP processes. This is one of them and depending on whether or not you think it's appropriate I might add skeletons for `GenServer`, `DynamicSupervisor`, etc.