### PR TITLE
Fix comma in array for ExUnit snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -392,7 +392,7 @@
 		"scope": "source.elixir"
 	},
 	"ExUnit": {
-		"prefix": ["ex_unit" "exu"],
+		"prefix": ["ex_unit", "exu"],
 		"body": [
 			"defmodule ${ModuleName}Test do",
 			"\tuse ExUnit.Case",


### PR DESCRIPTION
The malformed JSON array was tripping up another extension Snippets View which shows possible snippets for a file.