### PR TITLE
Generate module name from file path

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -394,12 +394,12 @@
 	"ExUnit": {
 		"prefix": ["ex_unit", "exu"],
 		"body": [
-			"defmodule ${ModuleName}Test do",
+			"defmodule${1:${TM_DIRECTORY/(^.+\\\/test|\\b)\\\/(\\w+)/${1:? :.}${2:/pascalcase}/g}.${TM_FILENAME_BASE/(.+)_test/${1:/pascalcase}/}}Test do",
 			"\tuse ExUnit.Case",
-			"\tdoctest ${ModuleName}",
+			"\tdoctest$1",
 			"",
-			"\tdescribe \"${description_of_tests}\" do",
-			"\t\ttest \"${definition_of_this_test}\" do",
+			"\tdescribe \"${2:description_of_tests}\" do",
+			"\t\ttest \"${3:definition_of_this_test}\" do",
 			"\t\tend",
 			"\tend",
 			"end"


### PR DESCRIPTION
`${TM_DIRECTORY/(^.+\\\/test|\\b)\\\/(\\w+)/${1:? :.}${2:/pascalcase}/g}`

When TM_DIRECTORY was '~/Document/some_project/test/some_long/path', it translate to ' SomeLong.Path'. (note that it has first space I can not reduce it 😓 )

`${TM_FILENAME_BASE/(.+)_test/${1:/pascalcase}/}`
When filename was some_module_test it translate to SomeModule