### PR TITLE
dmod: Generate namespace from folder names

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -73,7 +73,13 @@
 	},
 	"dmod": {
 		"prefix": ["dmod", "defmod"],
-		"body": "defmodule ${1:${TM_FILENAME_BASE/(.+)/${1:/pascalcase}/}} do\n\t$0\nend",
+		"body": [
+			// This monster of a regex optionally matches on up to 14 nested folders under lib|test|spec and generates the namespace name from those
+			// So a file with the path `lib/foo/bar/baz/boing.ex` would resolve to `defmodule Foo.Bar.Baz.Boing do`
+			"defmodule ${1:${TM_FILEPATH/^.*\\/(lib|test|spec)(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?\\/([^\\/]+)\\.exs?/${1:/pascalcase}${1:+.}${2:/pascalcase}${2:+.}${3:/pascalcase}${3:+.}${4:/pascalcase}${4:+.}${5:/pascalcase}${5:+.}${6:/pascalcase}${6:+.}${7:/pascalcase}${7:+.}${8:/pascalcase}${8:+.}${9:/pascalcase}${9:+.}${10:/pascalcase}${10:+.}${11:/pascalcase}${11:+.}${12:/pascalcase}${12:+.}${13:/pascalcase}${13:+.}${14:/pascalcase}${14:+.}${15:/pascalcase}/}} do",
+			"  $0",
+			"end",
+		],
 		"description": "def module",
 		"scope": "source.elixir"
 	},

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -76,7 +76,7 @@
 		"body": [
 			// This monster of a regex optionally matches on up to 14 nested folders under lib|test|spec and generates the namespace name from those
 			// So a file with the path `lib/foo/bar/baz/boing.ex` would resolve to `defmodule Foo.Bar.Baz.Boing do`
-			"defmodule ${1:${TM_FILEPATH/^.*\\/(lib|test|spec)(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?\\/([^\\/]+)\\.exs?/${1:/pascalcase}${1:+.}${2:/pascalcase}${2:+.}${3:/pascalcase}${3:+.}${4:/pascalcase}${4:+.}${5:/pascalcase}${5:+.}${6:/pascalcase}${6:+.}${7:/pascalcase}${7:+.}${8:/pascalcase}${8:+.}${9:/pascalcase}${9:+.}${10:/pascalcase}${10:+.}${11:/pascalcase}${11:+.}${12:/pascalcase}${12:+.}${13:/pascalcase}${13:+.}${14:/pascalcase}${14:+.}${15:/pascalcase}/}} do",
+			"defmodule ${1:${TM_FILEPATH/^.*\\/(?:lib|test|spec)(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?\\/([^\\/]+)\\.exs?/${1:/pascalcase}${1:+.}${2:/pascalcase}${2:+.}${3:/pascalcase}${3:+.}${4:/pascalcase}${4:+.}${5:/pascalcase}${5:+.}${6:/pascalcase}${6:+.}${7:/pascalcase}${7:+.}${8:/pascalcase}${8:+.}${9:/pascalcase}${9:+.}${10:/pascalcase}${10:+.}${11:/pascalcase}${11:+.}${12:/pascalcase}${12:+.}${13:/pascalcase}${13:+.}${14:/pascalcase}${14:+.}${15:/pascalcase}/}} do",
 			"  $0",
 			"end",
 		],


### PR DESCRIPTION
Sadly it's not possible to perform search and replace on matching groups, as such the regex has been written in such a fashion that it optionally matches on up to 14 nested folders (which should be plenty) under lib|test|spec.

For each of these folders it then performs a `pascalcase` transform, and appends a dot (`.`) if the matching group is non-empty.

As such in following file `lib/foo/bar/baz/boing.ex` `dmod` would resolve to:

```elixir
defmodule Foo.Bar.Baz.Boing do
  <cursor>
end
```

It's ugly as hell, but since JavaScript regexes don't support recursion, it's the best way we've got.

## Note

This breaks for any folder which isn't in `lib|test|spec`, would you consider this a problem?