### PR TITLE
Add snippet "pry" for "require IEx; IEx.pry"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Graciously borrowed all the snippets from the [TextMate bundle for Elixir](https
 | iip                | pipe to IO.inspect(module:line)                                                                          |
 | ip                 | IO.puts( ..)                                                                                             |
 | p                  | the pipeline operator                                                                                    |
+| pry                | IEx.pry                                                                                                  |
 | %                  | map/struct                                                                                               |
 | mdoc               | moduledoc                                                                                                |
 | mfs                | map from struct                                                                                          |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -254,6 +254,12 @@
     "description": "print_eex",
     "scope": "text.elixir,text.html.elixir"
   },
+  "pry": {
+    "prefix": "pry",
+    "body": "require IEx; IEx.pry",
+    "description": "Debug with IEx.pry",
+    "scope": "source.elixir"
+  },
   "rec": {
     "prefix": "rec",
     "body": "receive do\n\t${1:{${2::${3:message_type}}, ${4:value}\\}} ->\n    ${0:# code}\nend\n",


### PR DESCRIPTION
I use `require IEx; IEx.pry` quite often for debugging and would love to see a snippet for it.