### PR TITLE
Move defmodule comments to be inside a key

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -73,10 +73,12 @@
   },
   "dmod": {
     "prefix": ["dmod", "defmod"],
+    "comments": [
+      "This monster of a regex optionally matches on up to 15 nested folders under lib|test|spec and generates the namespace name from those.",
+      "So a file with the path `lib/foo/bar/baz/boing.ex` would resolve to `defmodule Foo.Bar.Baz.Boing do`.",
+      "If the file is not under lib|test|spec it will just use the filename to generate the module name."
+    ],
     "body": [
-      // This monster of a regex optionally matches on up to 15 nested folders under lib|test|spec and generates the namespace name from those.
-      // So a file with the path `lib/foo/bar/baz/boing.ex` would resolve to `defmodule Foo.Bar.Baz.Boing do`.
-      // If the file is not under lib|test|spec it will just use the filename to generate the module name.
       "defmodule ${1:${TM_FILEPATH/^(?:.*\\/(?:lib|test|spec)(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?\\/.*\\..*|.*)$/${1:/pascalcase}${1:+.}${2:/pascalcase}${2:+.}${3:/pascalcase}${3:+.}${4:/pascalcase}${4:+.}${5:/pascalcase}${5:+.}${6:/pascalcase}${6:+.}${7:/pascalcase}${7:+.}${8:/pascalcase}${8:+.}${9:/pascalcase}${9:+.}${10:/pascalcase}${10:+.}${11:/pascalcase}${11:+.}${12:/pascalcase}${12:+.}${13:/pascalcase}${13:+.}${14:/pascalcase}${14:+.}${15:/pascalcase}${15:+.}/}}${2:${TM_FILENAME_BASE/(.+)/${1:/pascalcase}/}} do",
       "  $0",
       "end"


### PR DESCRIPTION
As to not fail on parsers that are strict, for example, [vim-vsnip](https://github.com/hrsh7th/vim-vsnip) uses neovim's `json_decode` which fails: `[vsnip] Parsing error occurred on: ~/.local/share/nvim/plugged/vscode-elixir-snippets/snippets/snippets.json` because of the unrecognized chars `//`.

```vimscript
{'throwpint': 'function asyncomplete#_force_refresh[19]..<SNR>110_trigger[9]..<SNR>109_completor[11]..vsnip#get_complete_items[4]..vsnip#source#find[3]..vsnip#source
#vscode#find[1]..<SNR>226_find[40]..vsnip#source#create, line 5', 'exception': 'Vim(let):E474: Unidentified byte: // This monster of a regex optionally matches on up
 to 15 nested folders under lib|test|spec and generates the namespace name from those.^@      // So a file with the path `lib/foo/bar/baz/boing.ex` would resolve to
`defmodule Foo.Bar.Baz.Boing do`.^@      // If the file is not under lib|test|spec it will just use the filename to generate the module name.^@      "defmodule ${1:$
{TM_FILEPATH/^(?:.*\\/(?:lib|test|spec)(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/
]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?\\/.*\\..*|.*)$/${1:/pascalcase}${1:+.}${2:/pascalcase}${2:+.}${3:/pascalcase}${3:+.}${4:/pascal
case}${4:+.}${5:/pascalcase}${5:+.}${6:/pascalcase}${6:+.}${7:/pascalcase}${7:+.}${8:/pascalcase}${8:+.}${9:/pascalcase}${9:+.}${10:/pascalcase}${10:+.}${11:/pascalc
ase}${11:+.}${12:/pascalcase}${12:+.}${13:/pascalcase}${13:+.}${14:/pascalcase}${14:+.}${15:/pascalcase}${15:+.}/}}${2:${TM_FI'}
```

I tried to move then to a `comments: []` key but not sure if is the best way, wdyt?