### PR TITLE
Update regex to match any namespace

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -74,13 +74,12 @@
   "dmod": {
     "prefix": ["dmod", "defmod"],
     "comments": [
-      "This monster of a regex optionally matches on up to 15 nested folders under lib|test|spec and generates the namespace name from those.",
-      "So a file with the path `lib/foo/bar/baz/boing.ex` would resolve to `defmodule Foo.Bar.Baz.Boing do`.",
-      "If the file is not under lib|test|spec it will just use the filename to generate the module name."
+      "Generates the namespace for a file.",
+      "e.g. A file with the path `lib/foo/bar/baz/boing.ex` would resolve to Foo.Bar.Baz.Boing.",
     ],
     "body": [
-      "defmodule ${1:${TM_FILEPATH/^(?:.*\\/(?:lib|test|spec)(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?(\\/[^\\/]+)?\\/.*\\..*|.*)$/${1:/pascalcase}${1:+.}${2:/pascalcase}${2:+.}${3:/pascalcase}${3:+.}${4:/pascalcase}${4:+.}${5:/pascalcase}${5:+.}${6:/pascalcase}${6:+.}${7:/pascalcase}${7:+.}${8:/pascalcase}${8:+.}${9:/pascalcase}${9:+.}${10:/pascalcase}${10:+.}${11:/pascalcase}${11:+.}${12:/pascalcase}${12:+.}${13:/pascalcase}${13:+.}${14:/pascalcase}${14:+.}${15:/pascalcase}${15:+.}/}}${2:${TM_FILENAME_BASE/(.+)/${1:/pascalcase}/}} do",
-      "  $0",
+      "defmodule ${RELATIVE_FILEPATH/^([^\\/\\\\]+[\\/\\\\])|(\\.ex|\\.exs)$|([^._\\/\\\\]+)|_|([\\/\\\\])/${3:/capitalize}${4:+.}/g} do",
+      "\t$0",
       "end"
     ],
     "description": "def module",
@@ -215,6 +214,12 @@
     "description": "IO.puts(..)",
     "scope": "source.elixir"
   },
+  ":": {
+    "prefix": ":",
+    "body": "${1:value}: ${1:value}$0",
+    "description": "value: value",
+    "scope": "source.elixir"
+  },
   "::": {
     "prefix": "::",
     "body": "${1:key} => ${2:value}$0",
@@ -343,7 +348,7 @@
   "Supervisor": {
     "prefix": "supervisor",
     "body": [
-      "defmodule ${moduleName} do",
+      "defmodule ${RELATIVE_FILEPATH/^([^\\/\\\\]+[\\/\\\\])|(\\.ex|\\.exs)$|([^._\\/\\\\]+)|_|([\\/\\\\])/${3:/capitalize}${4:+.}/g} do",
       "\tuse Supervisor",
       "",
       "\tdef start_link(${args}) do",
@@ -363,7 +368,7 @@
   "DynamicSupervisor": {
     "prefix": "dynamic_supervisor",
     "body": [
-      "defmodule ${ModuleName} do",
+      "defmodule ${RELATIVE_FILEPATH/^([^\\/\\\\]+[\\/\\\\])|(\\.ex|\\.exs)$|([^._\\/\\\\]+)|_|([\\/\\\\])/${3:/capitalize}${4:+.}/g} do",
       "\tuse DynamicSupervisor",
       "",
       "\tdef start_link(${init_args}) do",
@@ -394,7 +399,7 @@
   "GenServer": {
     "prefix": "gen_server",
     "body": [
-      "defmodule ${ModuleName} do",
+      "defmodule ${RELATIVE_FILEPATH/^([^\\/\\\\]+[\\/\\\\])|(\\.ex|\\.exs)$|([^._\\/\\\\]+)|_|([\\/\\\\])/${3:/capitalize}${4:+.}/g} do",
       "\tuse GenServer",
       "",
       "\tdef start_link(${init_args}) do",
@@ -414,7 +419,7 @@
   "ExUnit": {
     "prefix": ["ex_unit", "exu"],
     "body": [
-      "defmodule${1:${TM_DIRECTORY/(^.+\\/test|\\b)\\/(\\w+)/${1:? :.}${2:/pascalcase}/g}.${TM_FILENAME_BASE/(.+)_test/${1:/pascalcase}/}}Test do",
+      "defmodule ${RELATIVE_FILEPATH/^([^\\/\\\\]+[\\/\\\\])|(\\.ex|\\.exs)$|([^._\\/\\\\]+)|_|([\\/\\\\])/${3:/capitalize}${4:+.}/g} do",
       "\tuse ExUnit.Case",
       "\tdoctest$1",
       "",


### PR DESCRIPTION
This regex uses the RELATIVE_FILEPATH instead of TM_FILEPATH variable and matches any level of nested folders based on my question in [StackOverflow](https://stackoverflow.com/questions/69145815/vs-code-snippet-regex-for-relative-path).

I also removed the "Test" at the end of the "ExUnit" snippet because my convention for file name includes "_test" at the end of the file and included the prefix ":", useful when the key and value are the same.