### PR TITLE
Add a snippet for inspecting stacktraces

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Graciously borrowed all the snippets from the [TextMate bundle for Elixir](https
 | iil                | IO.inspect(label: ..)                                                                                    |
 | iill               | IO.inspect with label incl. the line number                                                              |
 | iins               | `IO.inspect` with a label containing relative path and line number. Label string can easily be discarded |
+| ist                | `IO.inspect` the current stacktrace                                                                      |
 | iip                | pipe to IO.inspect(module:line)                                                                          |
 | ip                 | IO.puts( ..)                                                                                             |
 | p                  | the pipeline operator                                                                                    |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -211,6 +211,12 @@
     "description": "IO.inspect() piped value with module name & line number",
     "scope": "source.elixir"
   },
+  "ist": {
+    "prefix": "ist",
+    "body": "IO.inspect(Process.info(self(), :current_stacktrace), label: \"STACKTRACE\", limit: :infinity)",
+    "description": "`IO.inspect` the current stacktrace",
+    "scope": "source.elixir"
+  },
   "ip": {
     "prefix": "iip",
     "body": "IO.puts(\"$0\")",


### PR DESCRIPTION
Not sure if you're interested in contributions, but I use this all the time. ☺️ 

`ist` -> `IO.inspect(Process.info(self(), :current_stacktrace), label: "STACKTRACE", limit: :infinity)`