### PR TITLE
Add quotes to describe and test, add testc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Graciously borrowed all the snippets from the [TextMate bundle for Elixir](https
 | dmod               | defmodule                                                                                                |
 | defmc              | defmacrocallback                                                                                         |
 | defmp              | defmacrop                                                                                                |
-| describe           | describe .. do ..                                                                                        |
+| describe           | describe ".." do ..                                                                                      |
 | dmac               | defmacro                                                                                                 |
 | defp               | defp                                                                                                     |
 | defpro             | defprotocol                                                                                              |
@@ -60,7 +60,8 @@ Graciously borrowed all the snippets from the [TextMate bundle for Elixir](https
 | pe                 | print_eex                                                                                                |
 | rec                | receive                                                                                                  |
 | req                | require                                                                                                  |
-| test               | test .. do ..                                                                                            |
+| test               | test ".." do ..                                                                                          |
+| testc              | test "..", %{..} do ..                                                                                   |
 | unless             | unless                                                                                                   |
 | unlesse            | unless else                                                                                              |
 | unlesse:           | unless else (one line)                                                                                   |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -67,7 +67,7 @@
   },
   "describe": {
     "prefix": "describe",
-    "body": "describe $1 do\n\t$0\nend",
+    "body": "describe \"$1\" do\n\t$0\nend",
     "description": "describe",
     "scope": "source.elixir"
   },
@@ -333,8 +333,14 @@
   },
   "test": {
     "prefix": "test",
-    "body": "test $1 do\n\t$0\nend",
+    "body": "test \"$1\" do\n\t$0\nend",
     "description": "test",
+    "scope": "source.elixir"
+  },
+  "testc": {
+    "prefix": "testc",
+    "body": "test \"$1\", %{$2} do\n\t$0\nend",
+    "description": "test with context",
     "scope": "source.elixir"
   },
   "trc": {


### PR DESCRIPTION
Both describe and test expect to be given a string so here we surround the cursor in quotes when triggering the snippet.

`testc` is a test with context to more easily allow users to make tests utilizing the results of the test setup.
It adds a second tab target of an empty map, allowing you to easily add a `conn` or `user` or whatever you may want like:

```elixir
test "name of text", %{conn: conn} do

end
```
